### PR TITLE
Change "fredemmott/{hhvm-autoload, definition-finder}" requirements to "facebook/..."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "hhvm": "~3.12",
-        "facebook/definition-finder": "^1.3.3",
+        "facebook/definition-finder": "1.4.*",
         "appertly/cleopatra": "~0.1",
         "appertly/axe": "~0.1",
         "appertly/axe-markdown": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/log": "^1.0.0"
     },
     "require-dev": {
-	"hackpack/hackunit": "~0.6",
+        "hackpack/hackunit": "~0.6",
         "libreworks/psr3-log-hhi": "^1.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "psr/log": "^1.0.0"
     },
     "require-dev": {
+	"hackpack/hackunit": "~0.6",
         "libreworks/psr3-log-hhi": "^1.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,13 @@
     },
     "require": {
         "hhvm": "~3.12",
-        "fredemmott/definition-finder": "^1.3.3",
+        "facebook/definition-finder": "^1.3.3",
         "appertly/cleopatra": "~0.1",
         "appertly/axe": "~0.1",
         "appertly/axe-markdown": "~0.1",
         "psr/log": "^1.0.0"
     },
     "require-dev": {
-        "hackpack/hackunit": "~0.6",
         "libreworks/psr3-log-hhi": "^1.0.0"
     },
     "autoload": {

--- a/src/Collector.hh
+++ b/src/Collector.hh
@@ -19,9 +19,9 @@
  */
 namespace Hphpdoc;
 
-use FredEmmott\DefinitionFinder\FileParser;
-use FredEmmott\DefinitionFinder\TreeParser;
-use FredEmmott\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\FileParser;
+use Facebook\DefinitionFinder\TreeParser;
+use Facebook\DefinitionFinder\ScannedBase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareTrait;
 

--- a/src/Doc/ParameterTag.hh
+++ b/src/Doc/ParameterTag.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Doc;
 
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedTypehint;
 
 /**
  * Any tag that includes a typehint, a name, and a description.

--- a/src/Doc/Parser.hh
+++ b/src/Doc/Parser.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Doc;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedBase;
 
 /**
  * Parses doc comments

--- a/src/Doc/TagFactory.hh
+++ b/src/Doc/TagFactory.hh
@@ -19,12 +19,12 @@
  */
 namespace Hphpdoc\Doc;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedConstant;
-use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
-use FredEmmott\DefinitionFinder\ScannedMethod;
-use FredEmmott\DefinitionFinder\ScannedProperty;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedFunctionAbstract;
+use Facebook\DefinitionFinder\ScannedMethod;
+use Facebook\DefinitionFinder\ScannedProperty;
+use Facebook\DefinitionFinder\ScannedTypehint;
 
 /**
  * Creates tags.
@@ -250,7 +250,7 @@ class TagFactory
                 $t = 'array<' . substr($t, 0, -2) . '>';
             }
             $sourceCode = '<?hh function test(' . $t . ' $a) {}';
-            $tq = new \FredEmmott\DefinitionFinder\TokenQueue($sourceCode);
+            $tq = new \Facebook\DefinitionFinder\TokenQueue($sourceCode);
             while ($tq->haveTokens()) {
                 $tk = $tq->shift();
                 if ($tk[0] === '(') {
@@ -258,9 +258,9 @@ class TagFactory
                 }
             }
             try {
-                $tc = new \FredEmmott\DefinitionFinder\TypehintConsumer($tq, shape(
+                $tc = new \Facebook\DefinitionFinder\TypehintConsumer($tq, shape(
                   'filename' => $token?->getFileName() ?? '',
-                  'sourceType' => $token?->getSourceType() ?? \FredEmmott\DefinitionFinder\SourceType::HACK_PARTIAL,
+                  'sourceType' => $token?->getSourceType() ?? \Facebook\DefinitionFinder\SourceType::HACK_PARTIAL,
                   'namespace' => $token?->getNamespaceName(),
                   'aliases' => ImmMap{}, // TODO can we get this?
                   'genericTypeNames' => ImmSet{}, // TODO can we get this?

--- a/src/Doc/TypedTag.hh
+++ b/src/Doc/TypedTag.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Doc;
 
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedTypehint;
 
 /**
  * Any tag that includes only a typehint and a description.

--- a/src/Job.hh
+++ b/src/Job.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedBase;
 
 /**
  * Contains details of a job run.

--- a/src/Producer.hh
+++ b/src/Producer.hh
@@ -20,14 +20,14 @@
 namespace Hphpdoc;
 
 use Axe\Page;
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedEnum;
-use FredEmmott\DefinitionFinder\ScannedMethod;
-use FredEmmott\DefinitionFinder\ScannedNewtype;
-use FredEmmott\DefinitionFinder\ScannedProperty;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
-use FredEmmott\DefinitionFinder\ScannedType;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedEnum;
+use Facebook\DefinitionFinder\ScannedMethod;
+use Facebook\DefinitionFinder\ScannedNewtype;
+use Facebook\DefinitionFinder\ScannedProperty;
+use Facebook\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedType;
 
 /**
  * Contains helper methods for anything which generates content.

--- a/src/Publisher.hh
+++ b/src/Publisher.hh
@@ -20,10 +20,10 @@
 namespace Hphpdoc;
 
 use Axe\Page;
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedConstant;
-use FredEmmott\DefinitionFinder\ScannedFunction;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedFunction;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareTrait;
 use League\CommonMark\DocParser;

--- a/src/Source/ClassyDeclaration.hh
+++ b/src/Source/ClassyDeclaration.hh
@@ -19,10 +19,10 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedMethod;
-use FredEmmott\DefinitionFinder\ScannedProperty;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedMethod;
+use Facebook\DefinitionFinder\ScannedProperty;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\Parser;
 

--- a/src/Source/ConstantDeclaration.hh
+++ b/src/Source/ConstantDeclaration.hh
@@ -19,9 +19,9 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedConstant;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedTypehint;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\TypedTag;
 

--- a/src/Source/FunctionDeclaration.hh
+++ b/src/Source/FunctionDeclaration.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedFunction;
+use Facebook\DefinitionFinder\ScannedFunction;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\ParameterTag;
 use Hphpdoc\Doc\TypedTag;

--- a/src/Source/FunctionyDeclaration.hh
+++ b/src/Source/FunctionyDeclaration.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
+use Facebook\DefinitionFinder\ScannedFunctionAbstract;
 use Hphpdoc\Doc\ParameterTag;
 use Hphpdoc\Doc\TypedTag;
 

--- a/src/Source/Mapper.hh
+++ b/src/Source/Mapper.hh
@@ -19,10 +19,10 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedConstant;
-use FredEmmott\DefinitionFinder\ScannedFunction;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedFunction;
 use Hphpdoc\Doc\Parser;
 
 /**

--- a/src/Source/MethodDeclaration.hh
+++ b/src/Source/MethodDeclaration.hh
@@ -19,8 +19,8 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedMethod;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedMethod;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\ParameterTag;
 use Hphpdoc\Doc\TypedTag;

--- a/src/Source/PropertyDeclaration.hh
+++ b/src/Source/PropertyDeclaration.hh
@@ -19,9 +19,9 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedProperty;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedProperty;
+use Facebook\DefinitionFinder\ScannedTypehint;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\TypedTag;
 

--- a/src/Source/TokenDeclaration.hh
+++ b/src/Source/TokenDeclaration.hh
@@ -19,7 +19,7 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedBase;
 
 /**
  * A thing and its corresponding doc block

--- a/src/Source/TypeConstantDeclaration.hh
+++ b/src/Source/TypeConstantDeclaration.hh
@@ -19,9 +19,9 @@
  */
 namespace Hphpdoc\Source;
 
-use FredEmmott\DefinitionFinder\ScannedClass;
-use FredEmmott\DefinitionFinder\ScannedTypeConstant;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use Facebook\DefinitionFinder\ScannedClass;
+use Facebook\DefinitionFinder\ScannedTypeConstant;
+use Facebook\DefinitionFinder\ScannedTypehint;
 use Hphpdoc\Doc\Block;
 use Hphpdoc\Doc\TypedTag;
 

--- a/xhp/classlike.hh
+++ b/xhp/classlike.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedConstant;
 use Hphpdoc\Source\ClassyDeclaration;
 use Hphpdoc\Source\ConstantDeclaration;
 use Hphpdoc\Source\MethodDeclaration;
@@ -78,7 +78,7 @@ class :hphpdoc:classlike extends :x:element implements HasXHPHelpers
                     <div>
                         <code class="class-use">
                             {"use "}
-                            <hphpdoc:typehint token={new \FredEmmott\DefinitionFinder\ScannedTypehint($name, $generics, false)}/>
+                            <hphpdoc:typehint token={new \Facebook\DefinitionFinder\ScannedTypehint($name, $generics, false)}/>
                         </code>
                     </div>
                 );

--- a/xhp/constant.hh
+++ b/xhp/constant.hh
@@ -47,7 +47,7 @@ class :hphpdoc:constant extends :x:element implements HasXHPHelpers
         $mclass = $m->getClass();
         if ($mclass !== null && $cd instanceof Hphpdoc\Source\ClassyDeclaration
                 && $mclass->getName() !== $cd->getName()) {
-            $th = new FredEmmott\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
+            $th = new Facebook\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
             $labels->appendChild(
                 <span class="label">Inherited from <hphpdoc:typehint token={$th}/></span>
             );

--- a/xhp/constants.hh
+++ b/xhp/constants.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedConstant;
 use Hphpdoc\Source\ClassyDeclaration;
 use Hphpdoc\Source\MethodDeclaration;
 use Hphpdoc\Source\PropertyDeclaration;

--- a/xhp/function-trait.hh
+++ b/xhp/function-trait.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
+use Facebook\DefinitionFinder\ScannedFunctionAbstract;
 use Hphpdoc\Source\FunctionyDeclaration;
 use League\CommonMark\DocParser;
 

--- a/xhp/function.hh
+++ b/xhp/function.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
+use Facebook\DefinitionFinder\ScannedFunctionAbstract;
 use Hphpdoc\Source\FunctionDeclaration;
 use Hphpdoc\Source\FunctionyDeclaration;
 

--- a/xhp/functions.hh
+++ b/xhp/functions.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedConstant;
 use Hphpdoc\Source\ClassyDeclaration;
 use Hphpdoc\Source\MethodDeclaration;
 use Hphpdoc\Source\PropertyDeclaration;

--- a/xhp/generics.hh
+++ b/xhp/generics.hh
@@ -28,7 +28,7 @@ class :hphpdoc:generics extends :x:element implements HasXHPHelpers
     category %flow, %phrase;
     children empty;
     attribute :xhp:html-element,
-        ConstVector<FredEmmott\DefinitionFinder\ScannedGeneric> generics @required;
+        ConstVector<Facebook\DefinitionFinder\ScannedGeneric> generics @required;
 
     protected function render(): XHPRoot
     {

--- a/xhp/method.hh
+++ b/xhp/method.hh
@@ -46,7 +46,7 @@ class :hphpdoc:method extends :x:element implements HasXHPHelpers
         $labels = <p class="method-labels"/>;
         $mclass = $m->getClass();
         if ($cd->getName() !== $mclass->getName()) {
-            $th = new FredEmmott\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
+            $th = new Facebook\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
             $labels->appendChild(
                 <span class="label">Inherited from <hphpdoc:typehint token={$th}/></span>
             );

--- a/xhp/namespace.hh
+++ b/xhp/namespace.hh
@@ -18,12 +18,12 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedBasicClass;
-use FredEmmott\DefinitionFinder\ScannedBase;
-use FredEmmott\DefinitionFinder\ScannedConstant;
-use FredEmmott\DefinitionFinder\ScannedTrait;
-use FredEmmott\DefinitionFinder\ScannedInterface;
-use FredEmmott\DefinitionFinder\ScannedFunction;
+use Facebook\DefinitionFinder\ScannedBasicClass;
+use Facebook\DefinitionFinder\ScannedBase;
+use Facebook\DefinitionFinder\ScannedConstant;
+use Facebook\DefinitionFinder\ScannedTrait;
+use Facebook\DefinitionFinder\ScannedInterface;
+use Facebook\DefinitionFinder\ScannedFunction;
 use Hphpdoc\Source\TokenDeclaration;
 use Hphpdoc\Job;
 

--- a/xhp/parameters.hh
+++ b/xhp/parameters.hh
@@ -18,7 +18,7 @@
  * @license   Apache-2.0
  */
 
-use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
+use Facebook\DefinitionFinder\ScannedFunctionAbstract;
 
 /**
  * Renders method parameters.

--- a/xhp/property.hh
+++ b/xhp/property.hh
@@ -48,7 +48,7 @@ class :hphpdoc:property extends :x:element implements HasXHPHelpers
         $labels = <p class="method-labels"/>;
         $mclass = $m->getClass();
         if ($cd->getName() !== $mclass->getName()) {
-            $th = new FredEmmott\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
+            $th = new Facebook\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
             $labels->appendChild(
                 <span class="label">Inherited from <hphpdoc:typehint token={$th}/></span>
             );

--- a/xhp/type-constant.hh
+++ b/xhp/type-constant.hh
@@ -47,7 +47,7 @@ class :hphpdoc:type-constant extends :x:element implements HasXHPHelpers
         $mclass = $m->getClass();
         if ($mclass !== null && $cd instanceof Hphpdoc\Source\ClassyDeclaration
                 && $mclass->getName() !== $cd->getName()) {
-            $th = new FredEmmott\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
+            $th = new Facebook\DefinitionFinder\ScannedTypehint($mclass->getName(), Vector{}, false);
             $labels->appendChild(
                 <span class="label">Inherited from <hphpdoc:typehint token={$th}/></span>
             );

--- a/xhp/typehint.hh
+++ b/xhp/typehint.hh
@@ -31,7 +31,7 @@ class :hphpdoc:typehint extends :x:element implements HasXHPHelpers
     attribute :xhp:html-element,
         bool returnType = false,
         ?bool nullable = null,
-        ?FredEmmott\DefinitionFinder\ScannedTypehint token @required;
+        ?Facebook\DefinitionFinder\ScannedTypehint token @required;
 
     protected function render(): XHPRoot
     {

--- a/xhp/typehints.hh
+++ b/xhp/typehints.hh
@@ -29,7 +29,7 @@ class :hphpdoc:typehints extends :x:element implements HasXHPHelpers
     children empty;
     attribute :xhp:html-element,
         bool returnType = false,
-        ConstVector<?FredEmmott\DefinitionFinder\ScannedTypehint> tokens @required;
+        ConstVector<?Facebook\DefinitionFinder\ScannedTypehint> tokens @required;
 
     protected function render(): XHPRoot
     {


### PR DESCRIPTION
Fixes #2 . The `FredEmmott` namespace in `src/` and `xhp/` has been swapped for `Facebook`. 	f70a6d9 capped the version at 1.4.* because of some breaking changes.

The check fails because of the dev requirement on `hackunit`, which still specifies `fredemmott/definition-finder`.